### PR TITLE
Upgrade all actions to latest version for v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,26 +15,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Setup Java JDK
-      uses: actions/setup-java@v1.4.3
+      uses: actions/setup-java@v3
       with:
         java-version: 17
+        distribution: temurin
 
     - name: Build with Maven
       run: mvn clean verify --batch-mode ${{ inputs.mvnArgs }} ${{ secrets.mvnArgs }}
 
     - name: Publish Unit Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v1
+      uses: EnricoMi/publish-unit-test-result-action@v2
       if: always()
       with:
-        files: |
+        junit_files: |
           */target/*-reports/*.xml
           !*/target/*-reports/failsafe-summary.xml
 
     - name: Archive build artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         path: |
           */target/*.iar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,16 +8,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Get branch name
       id: branch-name
-      uses: tj-actions/branch-names@v4.5
+      uses: tj-actions/branch-names@v6
 
     - name: Setup Java JDK
-      uses: actions/setup-java@v1.4.3
+      uses: actions/setup-java@v3
       with:
         java-version: 17
+        distribution: temurin
         server-id: github
 
     - name: Configure Git


### PR DESCRIPTION
I'll re-tag after merge the latest commit with v2.

So all v2 users, will have the latest version.

Especially:
- the junit report shoudl be much better
- we now explicit build with temurin!