### PR TITLE
MARP-626 Introduce DEV-10 build for the connectors working on ivy 10

### DIFF
--- a/.github/workflows/dev-10.yml
+++ b/.github/workflows/dev-10.yml
@@ -9,10 +9,13 @@ on:
       ivyVersion:
         type: string
         default: nightly-10.0
-        description: the ivy version to use (e.g. dev/nightly/nightly-10/...)
+        description: the ivy version to use (e.g. dev/nightly/nightly-10.0/...)
     secrets:
       mvnArgs:
         required: false
+  pull_request:
+    branches:
+      - release/10.0
 
 jobs:
   build:

--- a/.github/workflows/dev-10.yml
+++ b/.github/workflows/dev-10.yml
@@ -1,4 +1,4 @@
-name: Dev-Build
+name: Dev-10-Build
 
 on: 
   workflow_call:

--- a/.github/workflows/dev-10.yml
+++ b/.github/workflows/dev-10.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build:
-    uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v3
+    uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v2
     with:
       mvnArgs: '"-Divy.engine.download.url=https://dev.axonivy.com/permalink/${{ inputs.ivyVersion }}/axonivy-engine.zip" "-Divy.engine.version=(10.0.0,]" ${{ inputs.mvnArgs }}'
     secrets:

--- a/.github/workflows/dev-10.yml
+++ b/.github/workflows/dev-10.yml
@@ -1,0 +1,23 @@
+name: Dev-Build
+
+on: 
+  workflow_call:
+    inputs:
+      mvnArgs:
+        type: string
+        required: false
+      ivyVersion:
+        type: string
+        default: nightly-10.0
+        description: the ivy version to use (e.g. dev/nightly/nightly-10/...)
+    secrets:
+      mvnArgs:
+        required: false
+
+jobs:
+  build:
+    uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v2
+    with:
+      mvnArgs: '"-Divy.engine.download.url=https://dev.axonivy.com/permalink/${{ inputs.ivyVersion }}/axonivy-engine.zip" "-Divy.engine.version=(10.0.0,]" ${{ inputs.mvnArgs }}'
+    secrets:
+      mvnArgs: '${{ secrets.mvnArgs }}'

--- a/.github/workflows/dev-10.yml
+++ b/.github/workflows/dev-10.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build:
-    uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v2
+    uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v3
     with:
       mvnArgs: '"-Divy.engine.download.url=https://dev.axonivy.com/permalink/${{ inputs.ivyVersion }}/axonivy-engine.zip" "-Divy.engine.version=(10.0.0,]" ${{ inputs.mvnArgs }}'
     secrets:

--- a/.github/workflows/dev-10.yml
+++ b/.github/workflows/dev-10.yml
@@ -13,7 +13,7 @@ on:
     secrets:
       mvnArgs:
         required: false
-  pull_request:
+  push:
     branches:
       - release/10.0
 

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -13,7 +13,7 @@ on:
     secrets:
       mvnArgs:
         required: false
-  pull_request:
+  push:
     branches:
       - master
 

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -9,7 +9,7 @@ on:
       ivyVersion:
         type: string
         default: dev
-        description: the ivy version to use (e.g. dev/nightly/nightly-10/...)
+        description: the ivy version to use (e.g. dev/nightly/nightly-10.0/...)
     secrets:
       mvnArgs:
         required: false

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build:
-    uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v3
+    uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v2
     with:
       mvnArgs: '"-Divy.engine.download.url=https://dev.axonivy.com/permalink/${{ inputs.ivyVersion }}/axonivy-engine.zip" "-Divy.engine.version=(10.0.0,]" ${{ inputs.mvnArgs }}'
     secrets:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -13,6 +13,9 @@ on:
     secrets:
       mvnArgs:
         required: false
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build:
-    uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v2
+    uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v3
     with:
       mvnArgs: '"-Divy.engine.download.url=https://dev.axonivy.com/permalink/${{ inputs.ivyVersion }}/axonivy-engine.zip" "-Divy.engine.version=(10.0.0,]" ${{ inputs.mvnArgs }}'
     secrets:


### PR DESCRIPTION
Hi @weissreto @ivy-rew 

I'm working on the story https://1ivy.atlassian.net/browse/MARP-626 to fix Dev-Fail on Market Monitor.
As the first step, I want to introduce a new `Dev-10-Build` build to watch the branch `release/10`, and trigger the build with the engine ivy `nightly-10.0` for the connectors working on the ivy engine 10.
I will create a new branch `release/10` for each market item working on the Ivy engine 10 and apply that build.
And for the `Dev-build`, it will watch only the branch `master`. We already have another story to convert projects to the latest version to resolve the failed `Dev-build`.

Please review this pull request and give us your feedback/ideas.
I'm looking forward to your feedback/ideas.