### PR TITLE
introduce dev-pipeline inputs for project-build-plugin version

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -10,6 +10,12 @@ on:
         type: string
         default: dev
         description: the ivy version to use (e.g. dev/nightly/nightly-10/...)
+      ivyPluginVersion:
+        type: string
+        default: 11.4.0-SNAPSHOT
+      testerVersion:
+        type: string
+        default: 11.4.0-SNAPSHOT
     secrets:
       mvnArgs:
         required: false
@@ -18,7 +24,7 @@ jobs:
   build:
     uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v2
     with:
-      mvnArgs: '"-Divy.engine.download.url=https://dev.axonivy.com/permalink/${{ inputs.ivyVersion }}/axonivy-engine.zip" "-Divy.engine.version=(10.0.0,]" ${{ inputs.mvnArgs }}'
+      mvnArgs: '"-Divy.engine.download.url=https://dev.axonivy.com/permalink/${{ inputs.ivyVersion }}/axonivy-engine.zip" "-Divy.engine.version=(10.0.0,]" "-Dproject.build.plugin.version=${{ inputs.ivyPluginVersion }}" "-Dtester.version=${{ inputs.testerVersion }}" ${{ inputs.mvnArgs }}'
       javaVersion: 21
       mvnVersion: 3.9.8
     secrets:


### PR DESCRIPTION
simplify the dev-build: so that consumers not have to re-state the leading-edge properties