### PR TITLE
archive built JAR files on CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
       with:
         path: |
           */target/*.iar
+          */target/*.jar
           *product/target/*.zip
 
     - name: Archive test reports


### PR DESCRIPTION
- p2-extension artifacts or pure java-api extensions for the core are built only as JAR