### PR TITLE
Fail build on unit-test errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         maven-version: ${{ inputs.mvnVersion }}
 
     - name: Build with Maven
-      run: mvn clean verify --batch-mode ${{ inputs.mvnArgs }} ${{ secrets.mvnArgs }}
+      run: mvn clean verify --batch-mode --fail-at-end ${{ inputs.mvnArgs }} ${{ secrets.mvnArgs }}
 
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         maven-version: ${{ inputs.mvnVersion }}
 
     - name: Build with Maven
-      run: mvn clean verify -Dmaven.test.failure.ignore=true --batch-mode ${{ inputs.mvnArgs }} ${{ secrets.mvnArgs }}
+      run: mvn clean verify --batch-mode ${{ inputs.mvnArgs }} ${{ secrets.mvnArgs }}
 
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action@v2


### PR DESCRIPTION
I can't remember why did use 'ignore.test.errors', but it seems like -fae is what we were looking for.
The pipeline should be indeed in status 'failing' -> 'red' when unit-tests fail.
But we should still run the full build, to get consistent outputs of surefire-repors, archived artifacts and the like.

Applied this concept temporarily on msgraph and it seems to work as expected: https://github.com/axonivy-market/msgraph-connector/tree/fail
... will introduce v4 so that clients can opt-in to this feature.