### PR TITLE
MARP-620 Update release drafter workflow with multiple options

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,4 +1,4 @@
-name-template: 'v$RESOLVED_VERSION 🧪'
+name-template: 'v$RESOLVED_VERSION 🛒'
 tag-template: 'v$RESOLVED_VERSION'
 categories:
   - title: '🚀 Features'
@@ -34,6 +34,13 @@ version-resolver:
     labels:
       - 'patch'
   default: patch
+autolabeler:
+  - label: 'bug'
+    branch:
+      - '/(bugfix|fix)\/.+/'
+  - label: 'enhancement'
+    branch:
+      - '/(feature)\/.+/'
 template: |
   ## Changes
 

--- a/.github/self-release-drafter.yml
+++ b/.github/self-release-drafter.yml
@@ -1,0 +1,40 @@
+name-template: 'v$RESOLVED_VERSION 🧪'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '📦 Dependencies'
+    label: 'dependencies'
+  - title: ⚠️ Changes
+    labels:
+      - deprecated
+  - title: 📄 Documentation
+    labels:
+      - docs
+      - documentation
+exclude-labels:
+  - 'skip-changelog'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,11 +1,6 @@
 name: Release Drafter
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-    types: [opened, reopened, synchronize]
   workflow_call:
     inputs:
       version:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,16 +2,20 @@ name: Release Drafter
 
 on:
   push:
-    # branches to consider in the event; optional, defaults to all
     branches:
       - master
-  # pull_request event is required only for autolabeler
   pull_request:
-    # Only following types are handled by the action, but one can default to all as well
     types: [opened, reopened, synchronize]
-  # pull_request_target event is required for autolabeler to support PRs from forks
-  # pull_request_target:
-  #   types: [opened, reopened, synchronize]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version'
+        required: true
+      prerelease:
+        description: 'Is this a prerelease?'
+        required: false
+        default: 'false'
+        type: boolean
 
 permissions:
   contents: read
@@ -19,23 +23,40 @@ permissions:
 jobs:
   update_release_draft:
     permissions:
-      # write permission is required to create a github release
       contents: write
-      # write permission is required for autolabeler
-      # otherwise, read permission is required at least
       pull-requests: write
-    runs-on: ubuntu-latest
+    env:
+      IS_PUSH_EVENT_TRIGGERED: ${{ github.event_name == 'push' }}
+      COMMITISH: 'master'
     steps:
-      # (Optional) GitHub Enterprise requires GHE_HOST variable set
-      #- name: Set GHE_HOST
-      #  run: |
-      #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
+      - name: Checkout code
+        if: env.IS_PUSH_EVENT_TRIGGERED == 'false'
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - name: Get commit SHA for the provided version
+        id: get-sha
+        if: env.IS_PUSH_EVENT_TRIGGERED == 'false'
+        run: |
+          # Attempt to fetch the SHA for the provided version tag
+          SHA=$(git rev-list -n 1 ${{ github.event.inputs.version }} || echo "")
+          
+          # If SHA is empty, fallback to master branch
+          if [ -z "$SHA" ]; then
+            echo "Could not find SHA for the provided version. Falling back to master."
+            SHA="master"
+          fi
+          echo "COMMITISH=$SHA" >> $GITHUB_ENV
+
+      - name: Set commitish for push
+        if: env.IS_PUSH_EVENT_TRIGGERED == 'true'
+        run: echo "COMMITISH=master" >> $GITHUB_ENV
+      
       - uses: release-drafter/release-drafter@v6
-        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
-        # with:
-        #   config-name: my-config.yml
-        #   disable-autolabeler: true
+        with:
+          version: ${{ github.event.inputs.version }}
+          prerelease: ${{ github.event.inputs.prerelease }}
+          commitish: ${{ env.COMMITISH }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
     types: [opened, reopened, synchronize]
-  workflow_dispatch:
+  workflow_call:
     inputs:
       version:
         description: 'Release version'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,4 +1,4 @@
-name: Release Drafter
+name: Reusable Release Drafter
 
 on:
   workflow_call:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,12 +5,13 @@ on:
     inputs:
       version:
         description: 'Release version'
-        required: true
+        required: false
+        type: string
       prerelease:
         description: 'Is this a prerelease?'
         required: false
         default: 'false'
-        type: boolean
+        type: string
 
 permissions:
   contents: read
@@ -23,6 +24,7 @@ jobs:
     env:
       IS_PUSH_EVENT_TRIGGERED: ${{ github.event_name == 'push' }}
       COMMITISH: 'master'
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         if: env.IS_PUSH_EVENT_TRIGGERED == 'false'

--- a/.github/workflows/self-release-drafter.yml
+++ b/.github/workflows/self-release-drafter.yml
@@ -1,0 +1,22 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/self-release-drafter.yml
+++ b/.github/workflows/self-release-drafter.yml
@@ -18,5 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: self-release-drafter.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I would like to update release drafter workflow which will:
1. Provide the ability to manually create a pre-release note and create the release note for old tag
2. Auto label PRs if the target branches contain some keywords.