### PR TITLE
MARP-1053 Update logic for generating release in release drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Configure Release Draft Settings
         run: |
-          if [ "$GITHUB_EVENT_NAME" != "push" ]; then
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_EVENT_NAME" == "pull_request_target" ]]; then
             exit 0
           fi
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -32,7 +32,7 @@ jobs:
           name: ${{ env.DRAFTER_NAME }}
           tag: ${{ env.DRAFTER_TAG }}
           commitish: ${{ github.ref }}
-          disable-releaser: ${{ github.event_name != 'push' }}
+          disable-releaser: ${{ contains(fromJSON('["pull_request", "pull_request_target"]'), github.event_name) }}
           
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
At first, we set it so only `push` events could generate a release, and other events were just for labeling pull requests. However, the Portal also uses `workflow_dispatch` to manually generate releases, so I updated the logic to support that.