### PR TITLE
MARP-1982 Adapt ci build for multi environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,8 @@ jobs:
     - name: Publish Unit Test Results
       id: test_report
       uses: dorny/test-reporter@v1.9.1
-      if: always()
       with:
-        name: Test Results
+        name: JUnit Test Results
         reporter: java-junit
         path: '**/target/*-reports/*.xml'
 
@@ -53,7 +52,6 @@ jobs:
 
     - name: Archive test json file
       uses: actions/upload-artifact@v4
-      if: failure()
       with:
         name: export-test-json-file
         retention-days: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,14 +37,16 @@ jobs:
     - name: Build with Maven
       run: mvn clean verify --batch-mode --fail-at-end ${{ inputs.mvnArgs }} ${{ secrets.mvnArgs }}
 
+    - name: Remove test summary file
+      run: rm -f **/target/*-reports/*-summary.xml
+
     - name: Publish Unit Test Results
       id: test_report
       uses: dorny/test-reporter@v1.9.1
-      if: always()
       with:
         name: JUnit Test Results
         reporter: java-junit
-        path: '**/target/*-reports/!(*-summary).xml'
+        path: '**/target/*-reports/*.xml'
 
     - name: Export test results to json file
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Build with Maven
       run: mvn clean verify --batch-mode --fail-at-end ${{ inputs.mvnArgs }} ${{ secrets.mvnArgs }}
 
-    - name: Remove test summary file
+    - name: Remove test summary files
       run: rm -f **/target/*-reports/*-summary.xml
 
     - name: Publish Unit Test Results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,11 @@ jobs:
     - name: Publish Unit Test Results
       id: test_report
       uses: dorny/test-reporter@v1.9.1
+      if: always()
       with:
         name: JUnit Test Results
         reporter: java-junit
-        path: '**/target/*-reports/*.xml'
+        path: '**/target/*-reports/!(*-summary).xml'
 
     - name: Export test results to json file
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
     - name: Publish Unit Test Results
       id: test_report
       uses: dorny/test-reporter@v1.9.1
+      if: always()
       with:
         name: JUnit Test Results
         reporter: java-junit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,26 @@ jobs:
       run: mvn clean verify --batch-mode --fail-at-end ${{ inputs.mvnArgs }} ${{ secrets.mvnArgs }}
 
     - name: Publish Unit Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v2
+      id: test_report
+      uses: dorny/test-reporter@v1.9.1
       if: always()
       with:
-        junit_files: |
-          */target/*-reports/*.xml
-          !*/target/*-reports/failsafe-summary.xml
+        name: Test Results
+        reporter: java-junit
+        path: '**/target/*-reports/*.xml'
+
+    - name: Export test results to json file
+      run: |
+        response=$(curl ${{ steps.test_report.outputs.url }})
+        echo $response > test_report.json
+
+    - name: Archive test json file
+      uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: export-test-json-file
+        retention-days: 5
+        path: 'test_report.json'
 
     - name: Archive build artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   build:
-    uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v5
+    uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v6
     with:
       mvnArgs: '"-Divy.engine.download.url=https://dev.axonivy.com/permalink/${{ inputs.ivyVersion }}/axonivy-engine.zip" "-Divy.engine.version=(12.0.0,]" "-Dproject.build.plugin.version=${{ inputs.ivyPluginVersion }}" "-Dtester.version=${{ inputs.testerVersion }}" ${{ inputs.mvnArgs }}'
       javaVersion: 21


### PR DESCRIPTION
Hi verifers,
I want to use **dorny/test-reporter** to get more detailed information about the test results with multiple environments.
In the image below, we can easily know the status of the test and the environment in which the test was executed.
Please give me your feedback on this change.
![image](https://github.com/user-attachments/assets/6c50bf50-56f5-4ae4-a3d2-7c9a5a206bc7)
