### PR TITLE
MARP-2279 enhance dorny test-reporter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,11 @@ on:
       mvnArgs:
         required: false
 
-permissions:
-  checks: write
-
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    permissions:
+      checks: write
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,8 @@ on:
     secrets:
       mvnArgs:
         required: false
+
 permissions:
-  contents: read
-  actions: read
   checks: write
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,14 @@ jobs:
         retention-days: 5
         path: 'test_report.json'
 
+    - name: Publish Unit Test Results
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      if: github.event.pull_request.head.repo.full_name != github.repository
+      with:
+        junit_files: |
+          */target/*-reports/*.xml
+          !*/target/*-reports/failsafe-summary.xml
+  
     - name: Archive build artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    permissions:
-      checks: write
-      contents: write
-      actions: write
-
     steps:
     - uses: actions/checkout@v4
 
@@ -44,6 +39,7 @@ jobs:
 
     - name: Check if test results exist
       id: check_test_files
+      if: github.event.pull_request.head.repo.full_name == github.repository
       run: |
         if [[ "${{ hashFiles('**/target/*-reports/*.xml') }}" != "" ]]; then
           echo "exists=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ on:
     secrets:
       mvnArgs:
         required: false
+permissions:
+  contents: read
+  actions: read
+  checks: write
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
     permissions:
       checks: write
+      contents: write
+      actions: write
+
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
Hi @ivy-rew @Octopus-AxonIvy 
I changed the test workflow for the CI build.
With the pull requests from the fork repo, I would like to use EnricoMi/publish-unit-test-result-action.
The dorny/test-reporter uses the GitHub Checks API and requires the following permission checks: write.
<img width="302" alt="image" src="https://github.com/user-attachments/assets/d8633db0-43e1-4b3a-ae36-72d7ce831cfc" />
In the build, the `GITHUB_TOKEN Permissions` has permission checks: read.
Therefore, the error "Resource not accessible by integration" is always thrown.
For pull requests in the same repository, we will continue to use dorny/test-reporter to get the nice result of the end-to-end testing.
I tested the workflow at https://github.com/axonivy-market/cronjob/actions/runs/15870767461
Do you have any feedback?