### PR TITLE
Do not support pull_request_target

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Configure Release Draft Settings
         if: ${{ env.SKIP_DRAFTER != 'true' }}
         run: |
-          if [[ "$GITHUB_EVENT_NAME" == "pull_request" || "$GITHUB_EVENT_NAME" == "pull_request_target" ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
             exit 0
           fi
 
@@ -45,6 +45,6 @@ jobs:
           name: ${{ env.DRAFTER_NAME }}
           tag: ${{ env.DRAFTER_TAG }}
           commitish: ${{ github.ref }}
-          disable-releaser: ${{ contains(fromJSON('["pull_request", "pull_request_target"]'), github.event_name) }}
+          disable-releaser: ${{ contains(fromJSON('["pull_request"]'), github.event_name) }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It's dead code and raises our vulnerability to permission hijacking attacks. (reading secrets with elevated perms)

AFAIK we don't use this permission anyway ... following best-practice.:
https://docs.github.com/en/enterprise-cloud@latest/actions/reference/security/secure-use#mitigating-the-risks-of-untrusted-code-checkout