### PR TITLE
Chore: update target branch for dev build -> dev/14.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ on:
       ivyJavaHome:
         type: string
         default: $JAVA_HOME_21_X64
+      targetBranch:
+        type: string
+        required: false
+        description: Optional branch name to check out instead of the current ref
     secrets:
       mvnArgs:
         required: false
@@ -41,7 +45,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - name: Checkout code
+      uses: actions/checkout@v6
+      with:
+        ref: ${{ inputs.targetBranch || github.ref }}
 
     - name: Setup Java JDK
       uses: actions/setup-java@v5

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -35,6 +35,7 @@ jobs:
       mvnVersion: 3.9.8
       ivyVersion: ${{ inputs.ivyVersion }}
       ivyJavaHome: $JAVA_HOME_25_X64
+      targetBranch: dev/14.0
       migrateToLatestIvyVersion: true
     secrets:
       mvnArgs: '${{ secrets.mvnArgs }}'


### PR DESCRIPTION
After dedicated branch 'dev/14.0/ for integration, dev build still run in 'master' branch.
-> Update dev build status in our monitoring page from tracking ‘master' branch → new branch of ‘dev/14.0’ 