### PR TITLE
fix: dev-engine migrator must respect new .ivyproject file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,17 @@ jobs:
         gitName=$(basename ${gitDir})
         echo "Searching projects in ${gitDir}"
         projects=()
+        # collect 13.2
         for ivyPref in $(find ${gitDir} -name "ch.ivyteam.ivy.designer.prefs"); do
           project=$(dirname $(dirname $ivyPref))
+          if ! [ -f "${project}/pom.xml" ]; then
+            continue # prefs file not in natural project structure
+          fi
+          projects+=("${project}")
+        done
+        # collect 14
+        for ivyPro in $(find ${gitDir} -name ".ivyproject"); do
+          project=$(dirname $ivyPro)
           if ! [ -f "${project}/pom.xml" ]; then
             continue # prefs file not in natural project structure
           fi


### PR DESCRIPTION
fix project detection to run migration on them:
- on the way to LTS14 the ivy-core changed the storage location of the project version from .setting/ch.ivyteam.ivy.designer.prefs to .ivyproject. Now we support both formats 
- the 13.2 collection method can be removed once LTS14 is published.